### PR TITLE
useCommas hook to format token amounts functioning

### DIFF
--- a/src/Components/Account.js
+++ b/src/Components/Account.js
@@ -3,7 +3,7 @@ import Settings from './Settings';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { postGetContributorTokenAmount } from '../requests';
-
+import useCommas from '../hooks/useCommas';
 export default function Account() {
   const user = useSelector(state => state.auth.user);
   const navigate = useNavigate();
@@ -21,7 +21,9 @@ export default function Account() {
 
   useEffect(() => {
     const getTokenAmount = async () => {
-      await postGetContributorTokenAmount(owner, repo, '', user.ethereumAddress, '').then(res => setTokenAmount(res.amount));
+      await postGetContributorTokenAmount(owner, repo, '', user.ethereumAddress, '')
+        .then(res => useCommas(res.amount))
+        .then(tokens => setTokenAmount(tokens));
     };
     getTokenAmount();
   });

--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import superagent from 'superagent';
 import { postGetContributorTokenAmount, getRepoStatus } from '../requests';
-
+import useCommas from '../hooks/useCommas';
 const port = process.env.PORT || 'http://localhost:4000';
 
 export default function Home(props) {
@@ -13,6 +13,7 @@ export default function Home(props) {
   let username = user?.login;
 
   let [tokens, setTokens] = useState('');
+
   let avatar = user?.avatar_url || null;
 
   let [repo, setRepo] = useState('');
@@ -40,7 +41,9 @@ export default function Home(props) {
 
   useEffect(() => {
     const getTokenAmount = async () => {
-      await postGetContributorTokenAmount(owner, repo, '', user.ethereumAddress, '').then(res => setTokens(res.amount));
+      await postGetContributorTokenAmount(owner, repo, '', user.ethereumAddress, '')
+        .then(res => useCommas(res.amount))
+        .then(tokens => setTokens(tokens));
     };
     getTokenAmount();
   });

--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -12,7 +12,7 @@ export default function Home(props) {
   let name = user?.name;
   let username = user?.login;
 
-  let [tokens, setTokens] = useState('');
+  let [tokenAmount, setTokenAmount] = useState('');
 
   let avatar = user?.avatar_url || null;
 
@@ -43,7 +43,7 @@ export default function Home(props) {
     const getTokenAmount = async () => {
       await postGetContributorTokenAmount(owner, repo, '', user.ethereumAddress, '')
         .then(res => useCommas(res.amount))
-        .then(tokens => setTokens(tokens));
+        .then(tokens => setTokenAmount(tokens));
     };
     getTokenAmount();
   });
@@ -73,7 +73,7 @@ export default function Home(props) {
               <span>
                 <img src="../icons/tokens.png" />
               </span>
-              {tokens || 0} tokens
+              {tokenAmount || 0} tokens
             </span>
           ) : null}
 

--- a/src/Components/Transfer.js
+++ b/src/Components/Transfer.js
@@ -139,7 +139,7 @@ export default function Transfer(props) {
           </span>
         </header>
 
-        <form name="transfer" className="transfer" onSubmit={reviewHandler}>
+        <form name="transfer" className="transfer">
           <span>
             <label htmlFor="transfer" className="">
               Who would you like to transfer tokens to?

--- a/src/Components/Transfer.js
+++ b/src/Components/Transfer.js
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux';
 import superagent from 'superagent';
 import loadergif from '../loader.gif';
 import { postGetContributorID, postGetContributorTokenAmount } from '../requests';
-
+import useCommas from '../hooks/useCommas';
 export default function Transfer(props) {
   let user = useSelector(state => state.auth.user);
   let [repo, setRepo] = useState('');
@@ -40,7 +40,9 @@ export default function Transfer(props) {
 
   useEffect(() => {
     const getTokenAmount = async () => {
-      await postGetContributorTokenAmount(owner, repo, '', user.ethereumAddress, '').then(res => setTokenAmount(res.amount));
+      await postGetContributorTokenAmount(owner, repo, '', user.ethereumAddress, '')
+        .then(res => useCommas(res.amount))
+        .then(tokens => setTokenAmount(tokens));
     };
     getTokenAmount();
   });

--- a/src/Components/Transfer.js
+++ b/src/Components/Transfer.js
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux';
 import superagent from 'superagent';
 import loadergif from '../loader.gif';
 import { postGetContributorID, postGetContributorTokenAmount } from '../requests';
-import useCommas from '../hooks/useCommas';
+
 export default function Transfer(props) {
   let user = useSelector(state => state.auth.user);
   let [repo, setRepo] = useState('');
@@ -40,9 +40,9 @@ export default function Transfer(props) {
 
   useEffect(() => {
     const getTokenAmount = async () => {
-      await postGetContributorTokenAmount(owner, repo, '', user.ethereumAddress, '')
-        .then(res => useCommas(res.amount))
-        .then(tokens => setTokenAmount(tokens));
+      await postGetContributorTokenAmount(owner, repo, '', user.ethereumAddress, '').then(res =>
+        setTokenAmount(res.amount)
+      );
     };
     getTokenAmount();
   });
@@ -168,7 +168,7 @@ export default function Transfer(props) {
           </span>
 
           <span>
-            <button type="submit" className="startButton" onClick={() => reviewHandler()}>
+            <button type="button" className="startButton" onClick={() => reviewHandler()}>
               Review and Send
             </button>
           </span>

--- a/src/Components/Transfer.js
+++ b/src/Components/Transfer.js
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux';
 import superagent from 'superagent';
 import loadergif from '../loader.gif';
 import { postGetContributorID, postGetContributorTokenAmount } from '../requests';
-
+import useCommas from '../hooks/useCommas';
 export default function Transfer(props) {
   let user = useSelector(state => state.auth.user);
   let [repo, setRepo] = useState('');
@@ -17,7 +17,7 @@ export default function Transfer(props) {
   let [length, setLength] = useState(false);
 
   let [tokenAmount, setTokenAmount] = useState('');
-
+  let [tokenString, setTokenString] = useState('');
   let [invalidText, setInvalidText] = useState('');
 
   let [transfer, setTransfer] = useState({
@@ -46,6 +46,11 @@ export default function Transfer(props) {
     };
     getTokenAmount();
   });
+
+  useEffect(() => {
+    const string = useCommas(tokenAmount);
+    setTokenString(string);
+  }, [tokenAmount]);
 
   useEffect(() => {
     if (!transfer.recipientName.length) {
@@ -87,7 +92,7 @@ export default function Transfer(props) {
 
   const reviewHandler = () => {
     if (Number(transfer.amount) < 1) {
-      setInvalidText(`Please enter a number between 1 and ${tokenAmount}`);
+      setInvalidText(`Please enter a number between 1 and ${tokenString}`);
     }
     if (Number(transfer.amount) > Number(tokenAmount)) {
       setInvalidText('Amount exceeds current balance.');
@@ -130,11 +135,11 @@ export default function Transfer(props) {
         <header>
           <h2>Transfer {repo} Tokens</h2>
           <span className="balance">
-            You currently have <text>{` ${tokenAmount || 0} ${repo}`}</text> tokens
+            You currently have <text>{` ${tokenString || 0} ${repo}`}</text> tokens
           </span>
         </header>
 
-        <form name="transfer" className="transfer">
+        <form name="transfer" className="transfer" onSubmit={reviewHandler}>
           <span>
             <label htmlFor="transfer" className="">
               Who would you like to transfer tokens to?

--- a/src/hooks/useCommas.js
+++ b/src/hooks/useCommas.js
@@ -1,0 +1,22 @@
+export default function useCommas(tokens) {
+  if (tokens === 0) {
+    return tokens;
+  }
+  if (tokens === 1000000) {
+    return '1,000,000';
+  } else if (tokens >= 100_000) {
+    const first = String(tokens).slice(0, 3);
+    const last = String(tokens).slice(3);
+    return `${first},${last}`;
+  } else if (tokens >= 10_000) {
+    const first = String(tokens).slice(0, 2);
+    const last = String(tokens).slice(2);
+    return `${first},${last}`;
+  } else if (tokens >= 1_000) {
+    const first = String(tokens).slice(0, 1);
+    const last = String(tokens).slice(1);
+    return `${first},${last}`;
+  } else {
+    return tokens;
+  }
+}


### PR DESCRIPTION
A hook was developed to place commas in our token amounts to be more legible in the UI. It is in a directory called hooks so as to not repeat the logic throughout the components. It is called useCommas, in keeping with the standard for React to entitle hooks beginning with the word use (useEffect, useDispatch, etc).

If a token amount is a million, the maximum, it simply returns a string of 1,000,000.

Otherwise if a token amount is equal to or greater than 100,000, it converts the number to a string, slices it at the first to the third index and again at the third index to the end to make two strings. It then returns these two strings with a comma in between.

The logic is repeated for 10,000 and 1,000.

Whenever postGetContributorTokenAmount is called for the UI, before setting the variable "tokenAmount" to its value, the hook is called and then that return value is set to the tokenAmount instead.

Before:
`
      await postGetContributorTokenAmount(owner, repo, '', user.ethereumAddress, '').then(res => setTokenAmount(res.tokenAmount));
`

After:
`
      await postGetContributorTokenAmount(owner, repo, '', user.ethereumAddress, '')
        .then(res => useCommas(res.amount)).then(tokens => setTokenAmount(tokens));
`

Additionally, "tokens" and "setTokens" in Home.js were changed to "tokenAmount" and "setTokenAmount" to be consistent with the other components such as Transfer.js and Account.js.