### PR TITLE
transfer bug fixed with correct repo id

### DIFF
--- a/src/Components/Onboard2.js
+++ b/src/Components/Onboard2.js
@@ -52,7 +52,7 @@ export default function Onboard2() {
   const createRepo = async () => {
     if (verified) {
       setLoader(true);
-      await postCreateRepo(user.login, repo, '', user.ethereumAddress, '').then(res => {
+      await postCreateRepo(owner, repo, '', user.ethereumAddress, '').then(res => {
         setLoader(false);
         if (res === '201') {
           navigate('/home');

--- a/src/Components/Review.js
+++ b/src/Components/Review.js
@@ -5,14 +5,14 @@ import { useSelector } from 'react-redux';
 import { postTransferTokens } from '../requests';
 export default function Review(props) {
   const user = useSelector(state => state.auth.user);
-  let { recipientId, recipientName, tokens, amount, setReview, setTransfer, repo, tokenAmount } = props;
+  let { recipientId, recipientName, tokens, amount, setReview, setTransfer, owner, repo, tokenAmount } = props;
   let [success, setSuccess] = useState(false);
   let [loader, setLoader] = useState(false);
 
   const clickHandler = async e => {
     setLoader(true);
 
-    await postTransferTokens(user.login, repo, user.ethereumAddress, recipientId, amount)
+    await postTransferTokens(owner, repo, user.ethereumAddress, recipientId, amount)
       .catch(error => setLoader(false))
       .then(() => setSuccess(true))
       .then(() => setLoader(false));

--- a/src/requests.js
+++ b/src/requests.js
@@ -140,25 +140,18 @@ async function postGetContributorTokenAmount(
     const json = JSON.parse(res.text);
     return json.data.getContributorTokenAmount;
 }
-
-async function postTransferTokens(owner, repo, from, to, amount) {
-  superagent
+async function postTransferTokens  (owner, repo, from, to, amount) {
+  const res = await superagent
     .post(`${port}/graphql`)
-    .send(
-      //{ query: '{ name: 'Manny', species: 'cat' }' }
-      //{ query: '{ newPullRequest(pr_id: "first", contributorId: "1", side: 1) { vote_code } }' }
-      //{ query: '{ getVote(pr_id: "default", contributorId: 1) {side} }' }
-      //{ query: '{ getVoteAll(pr_id: "default") { vote_code } }' }
-      //{ query: `{ getVoteEverything }` }
-      {
-        query: `{ transferTokens(owner: "${owner}", repo: "${repo}", from: "${from}", to: "${to}", amount: "${amount}") }`,
-      }
-      //{ query: '{ setVote(pr_id: "default" contributorId: "2", side: 1 ) { vote_code }' }
-    ) // sends a JSON post body
-    .set("accept", "json")
-    .end((err, res) => {
-      // Calling the end function will send the request
-    });
+    .send({
+      query: `{ transferTokens(owner: "${owner}", repo: "${repo}", from: "${from}", to: "${to}", amount: "${amount}") }`,
+    }) // sends a JSON post body
+    .set("accept", "json");
+  //   .end((err, res) => {
+  // Calling the end function will send the request
+  //   });
+  const json = JSON.parse(res.text);
+  return json.data.transferTokens;
 }
 
 async function postNewPullRequest(owner, repo, issue_id, contributor_id, side) {


### PR DESCRIPTION
Repo ids have always been <repo owner>/<repo name> as it appears in the Github dom.

This was changed for some reason, rendering other functions useless. This pr changes it back for transfer tokens. The other pr changes it back for createRepo.

Tests would have passed for David because the value user.login and owner are the same for 7db9a/demo.

